### PR TITLE
update implementations dict for new psycopg2 cursor type descriptor

### DIFF
--- a/upsert/__init__.py
+++ b/upsert/__init__.py
@@ -56,6 +56,6 @@ class Upsert:
     implementations = {
         "<type 'sqlite3.Cursor'>":              Sqlite3,
         "<class 'MySQLdb.cursors.Cursor'>":     Mysql,
-        "<type 'psycopg2._psycopg.cursor'>":    Postgresql
+        "<type 'psycopg2._psycopg.cursor'>":    Postgresql,
         "<type 'psycopg2.extensions.cursor'>":  Postgresql
     }

--- a/upsert/__init__.py
+++ b/upsert/__init__.py
@@ -48,7 +48,7 @@ class Upsert:
     def execute3(self, template, idents, values):
         pass1 = self.fill_ident_placeholders(template, idents)
         self.execute(pass1, values)
-    
+
     def fill_ident_placeholders(self, template, idents):
         quoted = tuple(self.quote_ident(str) for str in idents)
         return template % quoted
@@ -57,4 +57,5 @@ class Upsert:
         "<type 'sqlite3.Cursor'>":              Sqlite3,
         "<class 'MySQLdb.cursors.Cursor'>":     Mysql,
         "<type 'psycopg2._psycopg.cursor'>":    Postgresql
+        "<type 'psycopg2.extensions.cursor'>":  Postgresql
     }


### PR DESCRIPTION
Hi Seamus,

The type for a psycopg2 cursor can be 'psycopg2.extensions.cursor' , so i've added this to the mapping from cursor type to implementation.

lmk if you have any questions

-Chris
