### PR TITLE
Updates for work with Python3 (only made updates for sqlite3)

### DIFF
--- a/upsert/__init__.py
+++ b/upsert/__init__.py
@@ -54,7 +54,7 @@ class Upsert:
         return template % quoted
 
     implementations = {
-        "<type 'sqlite3.Cursor'>":              Sqlite3,
+        "<class 'sqlite3.Cursor'>":             Sqlite3,
         "<class 'MySQLdb.cursors.Cursor'>":     Mysql,
         "<type 'psycopg2._psycopg.cursor'>":    Postgresql,
         "<type 'psycopg2.extensions.cursor'>":  Postgresql

--- a/upsert/mysql.py
+++ b/upsert/mysql.py
@@ -13,7 +13,7 @@ class MergeFunction(upsert.MergeFunction):
         except Exception as e:
             if first_try and str(type(e)) == "<class '_mysql_exceptions.OperationalError'>" and e.args[0] == 1305:
                 first_try = False
-                print '[upsert] Trying to recreate function {0}'.format(self.name)
+                print ('[upsert] Trying to recreate function {0}'.format(self.name))
                 self.create_or_replace()
             else:
                 raise e

--- a/upsert/postgresql.py
+++ b/upsert/postgresql.py
@@ -13,7 +13,7 @@ class MergeFunction(upsert.MergeFunction):
         except Exception as e:
             if first_try and str(type(e)) == "<class 'psycopg2.ProgrammingError'>" and e.pgcode == 42883:
                 first_try = False
-                print '[upsert] Trying to recreate function {0}'.format(self.name)
+                print ('[upsert] Trying to recreate function {0}'.format(self.name))
                 self.create_or_replace()
             else:
                 raise e

--- a/upsert/sqlite3.py
+++ b/upsert/sqlite3.py
@@ -17,17 +17,17 @@ class Sqlite3(upsert.AnsiIdent):
         pi = ','.join(['%s']*len(setter))
         pv = ','.join(['?']*len(setter))
         a = 'INSERT OR IGNORE INTO %s (' + pi + ') VALUES ( ' + pv + ')'
-        b = [self.controller.table_name] + setter.keys()
+        b = [self.controller.table_name] + list(setter.keys())
         t = self.controller.fill_ident_placeholders(a, b)
-        vv = setter.values()
+        vv = list(setter.values())
         self.execute(t, vv)
-        
+
         selector_piv = ' AND '.join(['%s=?']*len(selector))
         setter_piv = ','.join(['%s=?']*len(setter))
         a = 'UPDATE %s SET ' + setter_piv + ' WHERE ' + selector_piv
-        b = [self.controller.table_name] + setter.keys() + selector.keys()
+        b = [self.controller.table_name] + list(setter.keys()) + list(selector.keys())
         t = self.controller.fill_ident_placeholders(a, b)
-        vv = setter.values() + selector.values()
+        vv = list(setter.values()) + list(selector.values())
         self.execute(t, vv)
 
     # so is this following DB-API and the others are breaking it?


### PR DESCRIPTION
I don't know if you plan on maintaining this anymore, but though I would make a pull request nonetheless. I only check whether these updates work for sqlite3. If any additional changes need to be made, it is likely related to .keys() and .values() needing to be wrapped in a list for concatenation, like I did in the sqlite3 code.